### PR TITLE
Verify after deploy

### DIFF
--- a/tasks/deploy.ts
+++ b/tasks/deploy.ts
@@ -21,6 +21,8 @@ task("deploy", "Deploy Storage", async (_, hre) => {
   console.log("Configuration file in ./artifacts/network.json");
   await writeFile("./artifacts/network.json", JSON.stringify(config, null, 2));
 
+  // It is recommended to wait for 5 confirmations before issuing the verification request
+  await storageContract.deployTransaction.wait(5);
   await hre.run("verify", {
     address: storageContract.address,
     contract: "contracts/Storage.sol:Storage",

--- a/tasks/deploy.ts
+++ b/tasks/deploy.ts
@@ -20,4 +20,10 @@ task("deploy", "Deploy Storage", async (_, hre) => {
 
   console.log("Configuration file in ./artifacts/network.json");
   await writeFile("./artifacts/network.json", JSON.stringify(config, null, 2));
+
+  await hre.run("verify", {
+    address: storageContract.address,
+    contract: "contracts/Storage.sol:Storage",
+    //constructorArgsParams: []
+  });
 });


### PR DESCRIPTION
Extend the sample deploy script to verify the deployed contract automatically after the deployment.